### PR TITLE
Updated requirements.txt for new version of packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
-mdutils==1.2.2
-requests==2.18.4
+certifi==2022.9.24
+charset-normalizer==2.1.1
+idna==3.4
+mdutils==1.4.0
+requests==2.28.1
+urllib3==1.26.12


### PR DESCRIPTION
Hi,

I took a liberty of trying to fix the action. 
Fix from @Foxhunt updated the required version of python, but one of the packages still used API from older version of python. So I updated the dependencies and it appears to work properly. 

Thank you and have a wonderful day.